### PR TITLE
613: Customising the tool to allow it to be run to create registrations for test TPP software statements

### DIFF
--- a/SBAT-README.MD
+++ b/SBAT-README.MD
@@ -1,0 +1,26 @@
+# Fork of OB Conformance DCR tool
+Upstream repo: https://github.com/OpenBankingUK/conformance-dcr
+
+## Repo structure
+
+The existing master branch will replicate the master in the upstream.
+
+A new branch: `sbat-master` has been created and made the default branch of the repo.
+All SBAT related changes must be made to this branch, the branch is protected so feature branch and PR flow must be followed.
+
+The upstream master will periodically be synced and can then be merged into sbat-master if we want to make use of the new commits.
+
+# SBAT Customisations
+This fork has been created to enable SBAT customisations to be applied to the conformance tool.
+
+In addition to running the conformance suite, the tool has been customised to enable the registration of test TPP applications.
+This customisation reuses the test code but only runs the DCR32CreateSoftwareClient scenario. This is used to create test applications in development environments.
+
+## New configuration options
+To customise behaviour, it has been necessary to create additional configuration options which can be used in the config.json
+
+| Key                                  | Type    | Usage                                                                                                                                                                                   |
+|--------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| create_software_client_only          | boolean | Used to control whether to run the whole suite or to only create a software client <br />Disabled by default                                                                            |
+| preferred_token_endpoint_auth_method | string  | (Optional) If specified then the DCR request will try to use this value as the token_endpoint_auth_method in the registration<br /><br />For SBAT we currently prefer `private_key_jwt` |
+

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -12,23 +12,25 @@ import (
 )
 
 type Config struct {
-	SpecVersion            string   `json:"spec_version"`
-	WellknownEndpoint      string   `json:"wellknown_endpoint"`
-	SSA                    string   `json:"ssa"`
-	Kid                    string   `json:"kid"`
-	Aud                    string   `json:"aud"`
-	RedirectURIs           []string `json:"redirect_uris"`
-	Issuer                 string   `json:"issuer"`
-	SigningKeyPEM          string   `json:"private_key"`
-	TransportRootCAsPEM    []string `json:"transport_root_cas"`
-	TransportCertSubjectDN string   `json:"transport_cert_subject_dn"`
-	TransportCertPEM       string   `json:"transport_cert"`
-	TransportKeyPEM        string   `json:"transport_key"`
-	GetImplemented         bool     `json:"get_implemented"`
-	PutImplemented         bool     `json:"put_implemented"`
-	DeleteImplemented      bool     `json:"delete_implemented"`
-	Environment            string   `json:"environment"`
-	Brand                  string   `json:"brand"`
+	SpecVersion                      string   `json:"spec_version"`
+	WellknownEndpoint                string   `json:"wellknown_endpoint"`
+	SSA                              string   `json:"ssa"`
+	Kid                              string   `json:"kid"`
+	Aud                              string   `json:"aud"`
+	RedirectURIs                     []string `json:"redirect_uris"`
+	Issuer                           string   `json:"issuer"`
+	SigningKeyPEM                    string   `json:"private_key"`
+	TransportRootCAsPEM              []string `json:"transport_root_cas"`
+	TransportCertSubjectDN           string   `json:"transport_cert_subject_dn"`
+	TransportCertPEM                 string   `json:"transport_cert"`
+	TransportKeyPEM                  string   `json:"transport_key"`
+	GetImplemented                   bool     `json:"get_implemented"`
+	PutImplemented                   bool     `json:"put_implemented"`
+	DeleteImplemented                bool     `json:"delete_implemented"`
+	Environment                      string   `json:"environment"`
+	Brand                            string   `json:"brand"`
+	PreferredTokenEndPointAuthMethod string   `json:"preferred_token_endpoint_auth_method"`
+	CreateSoftwareClientOnly         bool     `json:"create_software_client_only"`
 }
 
 func LoadConfig(configFilePath string) (Config, error) {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -83,6 +83,8 @@ func runCmd(flags flags) {
 		cfg.DeleteImplemented,
 		flags.tlsSkipVerify,
 		cfg.SpecVersion,
+		cfg.PreferredTokenEndPointAuthMethod,
+		cfg.CreateSoftwareClientOnly,
 	)
 	exitOnError(err)
 

--- a/pkg/compliant/auth/authoriser.go
+++ b/pkg/compliant/auth/authoriser.go
@@ -25,10 +25,36 @@ func NewAuthoriser(
 	jwtExpiration time.Duration,
 	transportCert *x509.Certificate,
 	transportSubjectDn string,
+	preferredTokenEndpointAuthMethod string,
 ) Authoriser {
 	requestObjectSignAlg := "none"
 	if len(config.RequestObjectSignAlgSupported) > 0 {
 		requestObjectSignAlg = config.RequestObjectSignAlgSupported[0]
+	}
+
+	if preferredTokenEndpointAuthMethod != "" {
+		if sliceContains(preferredTokenEndpointAuthMethod, config.TokenEndpointAuthMethodsSupported) {
+			return NewClientPrivateKeyJwt(
+				config.TokenEndpoint,
+				tokenEndpointSignMethod,
+				privateKey,
+				NewJwtSigner(
+					tokenEndpointSignMethod,
+					ssa,
+					issuer,
+					aud,
+					kid,
+					preferredTokenEndpointAuthMethod,
+					requestObjectSignAlg,
+					redirectURIs,
+					responseTypes,
+					privateKey,
+					jwtExpiration,
+					transportCert,
+					transportSubjectDn,
+				),
+			)
+		}
 	}
 
 	if sliceContains("tls_client_auth", config.TokenEndpointAuthMethodsSupported) {

--- a/pkg/compliant/auth/authoriser_builder.go
+++ b/pkg/compliant/auth/authoriser_builder.go
@@ -11,15 +11,16 @@ import (
 )
 
 type AuthoriserBuilder struct {
-	config                  openid.Configuration
-	ssa, aud, kID, issuer   string
-	tokenEndpointSignMethod jwt.SigningMethod
-	redirectURIs            []string
-	responseTypes           []string
-	privateKey              *rsa.PrivateKey
-	jwtExpiration           time.Duration
-	transportCert           *x509.Certificate
-	transportCertSubjectDn  string
+	config                           openid.Configuration
+	ssa, aud, kID, issuer            string
+	tokenEndpointSignMethod          jwt.SigningMethod
+	redirectURIs                     []string
+	responseTypes                    []string
+	privateKey                       *rsa.PrivateKey
+	jwtExpiration                    time.Duration
+	transportCert                    *x509.Certificate
+	transportCertSubjectDn           string
+	preferredTokenEndpointAuthMethod string
 }
 
 func NewAuthoriserBuilder() AuthoriserBuilder {
@@ -88,6 +89,11 @@ func (b AuthoriserBuilder) WithJwtExpiration(jwtExpiration time.Duration) Author
 	return b
 }
 
+func (b AuthoriserBuilder) WithPreferredTokenEndpointAuthMethod(tokenEndPointAuthMethod string) AuthoriserBuilder {
+	b.preferredTokenEndpointAuthMethod = tokenEndPointAuthMethod
+	return b
+}
+
 func (b AuthoriserBuilder) Build() (Authoriser, error) {
 	if b.ssa == "" {
 		return none{}, errors.New("missing ssa from authoriser")
@@ -114,5 +120,6 @@ func (b AuthoriserBuilder) Build() (Authoriser, error) {
 		b.jwtExpiration,
 		b.transportCert,
 		b.transportCertSubjectDn,
+		b.preferredTokenEndpointAuthMethod,
 	), nil
 }

--- a/pkg/compliant/auth/authoriser_builder_test.go
+++ b/pkg/compliant/auth/authoriser_builder_test.go
@@ -59,5 +59,6 @@ func Test_AuthoriserBuilder_Success(t *testing.T) {
 		0,
 		cert,
 		"",
+		"",
 	), authoriser)
 }

--- a/pkg/compliant/dcr.go
+++ b/pkg/compliant/dcr.go
@@ -9,6 +9,9 @@ func IsSupportedSpecVersion(version string) bool {
 func NewSpecManifest(version string, cfg DCR32Config) (Manifest, error) {
 	switch version {
 	case "3.2":
+		if cfg.CreateSoftwareClientOnly {
+			return NewDCR32CreateSoftwareClientOnly(cfg)
+		}
 		return NewDCR32(cfg)
 	case "3.3":
 		return NewDCR33(cfg)

--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -41,6 +41,16 @@ func NewDCR32(cfg DCR32Config) (Manifest, error) {
 	return NewManifest("DCR32", "1.0", scenarios)
 }
 
+func NewDCR32CreateSoftwareClientOnly(cfg DCR32Config) (Manifest, error) {
+	secureClient := cfg.SecureClient
+	authoriserBuilder := cfg.AuthoriserBuilder
+	scenarios := Scenarios{
+		DCR32CreateSoftwareClient(cfg, secureClient, authoriserBuilder),
+	}
+
+	return NewManifest("DCR32", "1.0", scenarios)
+}
+
 func DCR32ValidateOIDCConfigRegistrationURL(cfg DCR32Config) Scenario {
 	return NewBuilder(
 		"DCR-001",

--- a/pkg/compliant/dcr32_config.go
+++ b/pkg/compliant/dcr32_config.go
@@ -15,18 +15,19 @@ import (
 )
 
 type DCR32Config struct {
-	OpenIDConfig       openid.Configuration
-	SSA                string
-	KID                string
-	RedirectURIs       []string
-	TokenSigningMethod jwt.SigningMethod
-	PrivateKey         *rsa.PrivateKey
-	SecureClient       *http2.Client
-	GetImplemented     bool
-	PutImplemented     bool
-	DeleteImplemented  bool
-	AuthoriserBuilder  auth.AuthoriserBuilder
-	SchemaValidator    schema.Validator
+	OpenIDConfig             openid.Configuration
+	SSA                      string
+	KID                      string
+	RedirectURIs             []string
+	TokenSigningMethod       jwt.SigningMethod
+	PrivateKey               *rsa.PrivateKey
+	SecureClient             *http2.Client
+	GetImplemented           bool
+	PutImplemented           bool
+	DeleteImplemented        bool
+	AuthoriserBuilder        auth.AuthoriserBuilder
+	SchemaValidator          schema.Validator
+	CreateSoftwareClientOnly bool
 }
 
 func NewDCR32Config(
@@ -43,6 +44,8 @@ func NewDCR32Config(
 	deleteImplemented bool,
 	tlsSkipVerify bool,
 	specVersion string,
+	preferredTokenEndpointAuthMethod string,
+	createSoftwareClientOnly bool,
 ) (DCR32Config, error) {
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(signingKeyPEM))
 	if err != nil {
@@ -81,7 +84,8 @@ func NewDCR32Config(
 		WithPrivateKey(privateKey).
 		WithTokenEndpointAuthMethod(tokenSignMethod).
 		WithTransportCert(transportCert).
-		WithTransportCertSubjectDn(transportCertSubjectDn)
+		WithTransportCertSubjectDn(transportCertSubjectDn).
+		WithPreferredTokenEndpointAuthMethod(preferredTokenEndpointAuthMethod)
 
 	secureClient, err := http.NewBuilder().
 		WithRootCAs(transportRootCAs).
@@ -93,17 +97,18 @@ func NewDCR32Config(
 	}
 
 	return DCR32Config{
-		OpenIDConfig:      openIDConfig,
-		SSA:               ssa,
-		KID:               kid,
-		RedirectURIs:      redirectURIs,
-		PrivateKey:        privateKey,
-		SecureClient:      secureClient,
-		GetImplemented:    getImplemented,
-		PutImplemented:    putImplemented,
-		DeleteImplemented: deleteImplemented,
-		AuthoriserBuilder: authoriserBuilder,
-		SchemaValidator:   schemaValidator,
+		OpenIDConfig:             openIDConfig,
+		SSA:                      ssa,
+		KID:                      kid,
+		RedirectURIs:             redirectURIs,
+		PrivateKey:               privateKey,
+		SecureClient:             secureClient,
+		GetImplemented:           getImplemented,
+		PutImplemented:           putImplemented,
+		DeleteImplemented:        deleteImplemented,
+		AuthoriserBuilder:        authoriserBuilder,
+		SchemaValidator:          schemaValidator,
+		CreateSoftwareClientOnly: createSoftwareClientOnly,
 	}, nil
 }
 

--- a/pkg/compliant/dcr32_config_test.go
+++ b/pkg/compliant/dcr32_config_test.go
@@ -35,6 +35,8 @@ func TestNewDCR32Config(t *testing.T) {
 		false,
 		false,
 		"3.2",
+		"",
+		false,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Added SBAT-README.MD which documents development process and configuration customisations
- Updated test runner to only create registrations if desired (rather than run whole suite) via create_software_client_only config option
- Updated authoriser to allow the token_endpoint_auth_method to be configured in the registration, controlled via optional flag: preferred_token_endpoint_auth_method

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/613