### PR TITLE
613: Using registration_access_token as Authorization token when accessing an existing registration

### DIFF
--- a/pkg/compliant/auth/authoriser_test.go
+++ b/pkg/compliant/auth/authoriser_test.go
@@ -37,6 +37,7 @@ func TestNewAuther_ReturnsClientSecretBasic(t *testing.T) {
 		time.Hour,
 		nil,
 		"",
+		"",
 	)
 
 	assert.IsType(t, clientSecretBasic{}, auther)
@@ -59,6 +60,7 @@ func TestNewAuther_ReturnsPrivateKeyJwt(t *testing.T) {
 		&rsa.PrivateKey{},
 		time.Hour,
 		nil,
+		"",
 		"",
 	)
 
@@ -83,6 +85,7 @@ func TestNewAuther_ReturnsTlsClientAuth(t *testing.T) {
 		time.Hour,
 		nil,
 		"",
+		"",
 	)
 
 	assert.IsType(t, tlsClientAuth{}, auther)
@@ -105,6 +108,7 @@ func TestNewAuther_ReturnsNoAuther(t *testing.T) {
 		&rsa.PrivateKey{},
 		time.Hour,
 		nil,
+		"",
 		"",
 	)
 

--- a/pkg/compliant/auth/client_secret_basic.go
+++ b/pkg/compliant/auth/client_secret_basic.go
@@ -28,14 +28,16 @@ func (c clientSecretBasic) Client(response []byte) (client.Client, error) {
 
 	return client.NewClientSecretBasic(
 		registrationResponse.ClientID,
+		registrationResponse.RegistrationAccessToken,
 		registrationResponse.ClientSecret,
 		c.tokenEndpoint,
 	), nil
 }
 
 type OBClientRegistrationResponse struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret,omitempty"`
+	ClientID                string `json:"client_id"`
+	RegistrationAccessToken string `json:"registration_access_token"`
+	ClientSecret            string `json:"client_secret,omitempty"`
 }
 
 func (c clientSecretBasic) Claims() (string, error) {

--- a/pkg/compliant/auth/client_secret_basic_test.go
+++ b/pkg/compliant/auth/client_secret_basic_test.go
@@ -62,11 +62,12 @@ func TestClientSecretBasicAuther_Client_ReturnsAClient(t *testing.T) {
 		),
 	)
 
-	client, err := auther.Client([]byte(`{"client_id": "12345", "client_secret": "54321"}`))
+	client, err := auther.Client([]byte(`{"client_id": "12345", "registration_access_token": "abcdef", "client_secret": "54321"}`))
 	require.NoError(t, err)
 	r, err := client.CredentialsGrantRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "12345", client.Id())
+	assert.Equal(t, "abcdef", client.RegistrationAccessToken())
 
 	expectedTokenHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("12345:54321")))
 	assert.Equal(t, expectedTokenHeader, r.Header.Get("Authorization"))

--- a/pkg/compliant/auth/client_secret_jwt.go
+++ b/pkg/compliant/auth/client_secret_jwt.go
@@ -28,6 +28,7 @@ func (c clientSecretJWT) Client(response []byte) (client.Client, error) {
 
 	return client.NewClientSecretJwt(
 		registrationResponse.ClientID,
+		registrationResponse.RegistrationAccessToken,
 		registrationResponse.ClientSecret,
 		c.tokenEndpoint,
 	), nil

--- a/pkg/compliant/auth/client_secret_jwt_test.go
+++ b/pkg/compliant/auth/client_secret_jwt_test.go
@@ -60,8 +60,9 @@ func TestClientSecretJWT_Client_ReturnsAClient(t *testing.T) {
 		),
 	)
 
-	client, err := auther.Client([]byte(`{"client_id": "12345", "client_secret": "54321"}`))
+	client, err := auther.Client([]byte(`{"client_id": "12345", "registration_access_token": "abcdef", "client_secret": "54321"}`))
 
 	require.NoError(t, err)
 	assert.Equal(t, "12345", client.Id())
+	assert.Equal(t, "abcdef", client.RegistrationAccessToken())
 }

--- a/pkg/compliant/auth/private_key_jwt.go
+++ b/pkg/compliant/auth/private_key_jwt.go
@@ -39,6 +39,7 @@ func (c clientPrivateKeyJwt) Client(response []byte) (client.Client, error) {
 
 	return client.NewPrivateKeyJwt(
 		registrationResponse.ClientID,
+		registrationResponse.RegistrationAccessToken,
 		c.tokenEndpoint,
 		c.privateKey,
 		c.signingAlgorithm,

--- a/pkg/compliant/auth/private_key_jwt_test.go
+++ b/pkg/compliant/auth/private_key_jwt_test.go
@@ -12,11 +12,12 @@ func TestNewClientPrivateKeyJwt(t *testing.T) {
 	privateKey := &rsa.PrivateKey{}
 	a := NewClientPrivateKeyJwt("/token", jwt.SigningMethodPS256, privateKey, mockedSigner{})
 
-	data := []byte(`{"client_id": "12345"}`)
+	data := []byte(`{"client_id": "12345", "registration_access_token": "abcdef"}`)
 	client, err := a.Client(data)
 
 	require.NoError(t, err)
 	assert.Equal(t, "12345", client.Id())
+	assert.Equal(t, "abcdef", client.RegistrationAccessToken())
 }
 
 func TestNewClientPrivateKeyJwt_ClientHandlerMarshalError(t *testing.T) {

--- a/pkg/compliant/auth/tls_client_auth.go
+++ b/pkg/compliant/auth/tls_client_auth.go
@@ -28,6 +28,7 @@ func (c tlsClientAuth) Client(response []byte) (client.Client, error) {
 
 	return client.NewTlsClientAuth(
 		registrationResponse.ClientID,
+		registrationResponse.RegistrationAccessToken,
 		c.tokenEndpoint,
 	), nil
 }

--- a/pkg/compliant/auth/tls_client_auth_test.go
+++ b/pkg/compliant/auth/tls_client_auth_test.go
@@ -9,11 +9,12 @@ import (
 func TestNewTlsClientAuth(t *testing.T) {
 	a := NewTlsClientAuth("/token", mockedSigner{})
 
-	data := []byte(`{"client_id": "12345"}`)
+	data := []byte(`{"client_id": "12345", "registration_access_token": "abcdef"}`)
 	client, err := a.Client(data)
 
 	require.NoError(t, err)
 	assert.Equal(t, "12345", client.Id())
+	assert.Equal(t, "abcdef", client.RegistrationAccessToken())
 }
 
 func TestNewTlsClientAuth_ClientHandlerMarshalError(t *testing.T) {

--- a/pkg/compliant/client/client.go
+++ b/pkg/compliant/client/client.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 )
 
 type Client interface {
 	Id() string
+	RegistrationAccessToken() string
 	CredentialsGrantRequest() (*http.Request, error)
 }
 
@@ -20,6 +22,18 @@ func (c noClient) Id() string {
 	return ""
 }
 
+func (c noClient) RegistrationAccessToken() string {
+	return ""
+}
+
 func (c noClient) CredentialsGrantRequest() (*http.Request, error) {
 	return nil, nil
+}
+
+func AddRegistrationAccessTokenAuthHeader(req *http.Request, client Client) error {
+	if client.RegistrationAccessToken() == "" {
+		return errors.New("client has no RegistrationAccessToken")
+	}
+	req.Header.Set("Authorization", "Bearer "+client.RegistrationAccessToken())
+	return nil
 }

--- a/pkg/compliant/client/client_secret_basic.go
+++ b/pkg/compliant/client/client_secret_basic.go
@@ -10,21 +10,27 @@ import (
 )
 
 type clientSecretBasic struct {
-	id            string
-	secret        string
-	tokenEndpoint string
+	id                      string
+	registrationAccessToken string
+	secret                  string
+	tokenEndpoint           string
 }
 
-func NewClientSecretBasic(id, secret, tokenEndpoint string) Client {
+func NewClientSecretBasic(id, registrationAccessToken, secret, tokenEndpoint string) Client {
 	return clientSecretBasic{
-		id:            id,
-		secret:        secret,
-		tokenEndpoint: tokenEndpoint,
+		id:                      id,
+		registrationAccessToken: registrationAccessToken,
+		secret:                  secret,
+		tokenEndpoint:           tokenEndpoint,
 	}
 }
 
 func (c clientSecretBasic) Id() string {
 	return c.id
+}
+
+func (c clientSecretBasic) RegistrationAccessToken() string {
+	return c.registrationAccessToken
 }
 
 func (c clientSecretBasic) CredentialsGrantRequest() (*http.Request, error) {

--- a/pkg/compliant/client/client_secret_basic_test.go
+++ b/pkg/compliant/client/client_secret_basic_test.go
@@ -11,13 +11,14 @@ import (
 )
 
 func TestClientBasic(t *testing.T) {
-	client := NewClientSecretBasic("id", "secret", "http://endpoint")
+	client := NewClientSecretBasic("id", "regAccessToken", "secret", "http://endpoint")
 
 	expectedTokenHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("id:secret")))
 
 	request, err := client.CredentialsGrantRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "id", client.Id())
+	assert.Equal(t, "regAccessToken", client.RegistrationAccessToken())
 	assert.Equal(t, expectedTokenHeader, request.Header.Get("Authorization"))
 
 	bodyByes, err := ioutil.ReadAll(request.Body)

--- a/pkg/compliant/client/client_secret_jwt.go
+++ b/pkg/compliant/client/client_secret_jwt.go
@@ -11,21 +11,27 @@ import (
 )
 
 type clientSecretJwt struct {
-	id            string
-	tokenEndpoint string
-	clientSecret  string
+	id                      string
+	registrationAccessToken string
+	tokenEndpoint           string
+	clientSecret            string
 }
 
-func NewClientSecretJwt(id, clientSecret, tokenEndpoint string) Client {
+func NewClientSecretJwt(id, registrationAccessToken, clientSecret, tokenEndpoint string) Client {
 	return clientSecretJwt{
-		id:            id,
-		tokenEndpoint: tokenEndpoint,
-		clientSecret:  clientSecret,
+		id:                      id,
+		registrationAccessToken: registrationAccessToken,
+		tokenEndpoint:           tokenEndpoint,
+		clientSecret:            clientSecret,
 	}
 }
 
 func (c clientSecretJwt) Id() string {
 	return c.id
+}
+
+func (c clientSecretJwt) RegistrationAccessToken() string {
+	return c.registrationAccessToken
 }
 
 func (c clientSecretJwt) CredentialsGrantRequest() (*http.Request, error) {

--- a/pkg/compliant/client/client_secret_jwt_test.go
+++ b/pkg/compliant/client/client_secret_jwt_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 func TestClientSecretJWT(t *testing.T) {
-	client := NewClientSecretJwt("id", "secret", "/token_endpoint")
+	client := NewClientSecretJwt("id", "regAccessToken", "secret", "/token_endpoint")
 
 	request, err := client.CredentialsGrantRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "id", client.Id())
+	assert.Equal(t, "regAccessToken", client.RegistrationAccessToken())
 
 	bodyByes, err := ioutil.ReadAll(request.Body)
 	require.NoError(t, err)

--- a/pkg/compliant/client/private_key_jwt.go
+++ b/pkg/compliant/client/private_key_jwt.go
@@ -12,27 +12,33 @@ import (
 )
 
 type privateKeyJwt struct {
-	id               string
-	tokenEndpoint    string
-	privateKey       *rsa.PrivateKey
-	signingAlgorithm jwt.SigningMethod
+	id                      string
+	registrationAccessToken string
+	tokenEndpoint           string
+	privateKey              *rsa.PrivateKey
+	signingAlgorithm        jwt.SigningMethod
 }
 
 func NewPrivateKeyJwt(
-	id, tokenEndpoint string,
+	id, registrationAccessToken, tokenEndpoint string,
 	privateKey *rsa.PrivateKey,
 	signingAlgorithm jwt.SigningMethod,
 ) Client {
 	return privateKeyJwt{
-		id:               id,
-		tokenEndpoint:    tokenEndpoint,
-		privateKey:       privateKey,
-		signingAlgorithm: signingAlgorithm,
+		id:                      id,
+		registrationAccessToken: registrationAccessToken,
+		tokenEndpoint:           tokenEndpoint,
+		privateKey:              privateKey,
+		signingAlgorithm:        signingAlgorithm,
 	}
 }
 
 func (c privateKeyJwt) Id() string {
 	return c.id
+}
+
+func (c privateKeyJwt) RegistrationAccessToken() string {
+	return c.registrationAccessToken
 }
 
 func (c privateKeyJwt) CredentialsGrantRequest() (*http.Request, error) {

--- a/pkg/compliant/client/private_key_jwt_test.go
+++ b/pkg/compliant/client/private_key_jwt_test.go
@@ -14,11 +14,12 @@ import (
 func TestPrivateKeyJwt(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
-	client := NewPrivateKeyJwt("id", "token", key, jwt.SigningMethodPS256)
+	client := NewPrivateKeyJwt("id", "regAccessToken", "token", key, jwt.SigningMethodPS256)
 
 	request, err := client.CredentialsGrantRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "id", client.Id())
+	assert.Equal(t, "regAccessToken", client.RegistrationAccessToken())
 	bodyByes, err := ioutil.ReadAll(request.Body)
 	require.NoError(t, err)
 	bodyDecoded, err := url.ParseQuery(string(bodyByes))

--- a/pkg/compliant/client/tls_client.go
+++ b/pkg/compliant/client/tls_client.go
@@ -8,19 +8,25 @@ import (
 )
 
 type tlsClient struct {
-	id            string
-	tokenEndpoint string
+	id                      string
+	registrationAccessToken string
+	tokenEndpoint           string
 }
 
-func NewTlsClientAuth(id, tokenEndpoint string) Client {
+func NewTlsClientAuth(id, registrationAccessToken, tokenEndpoint string) Client {
 	return tlsClient{
-		id:            id,
-		tokenEndpoint: tokenEndpoint,
+		id:                      id,
+		registrationAccessToken: registrationAccessToken,
+		tokenEndpoint:           tokenEndpoint,
 	}
 }
 
 func (c tlsClient) Id() string {
 	return c.id
+}
+
+func (c tlsClient) RegistrationAccessToken() string {
+	return c.registrationAccessToken
 }
 
 func (c tlsClient) CredentialsGrantRequest() (*http.Request, error) {

--- a/pkg/compliant/client/tls_client_test.go
+++ b/pkg/compliant/client/tls_client_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 func TestClientTlsClientAuth(t *testing.T) {
-	client := NewTlsClientAuth("id", "token")
+	client := NewTlsClientAuth("id", "regAccessToken", "token")
 
 	request, err := client.CredentialsGrantRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "id", client.Id())
+	assert.Equal(t, "regAccessToken", client.RegistrationAccessToken())
 	bodyByes, err := ioutil.ReadAll(request.Body)
 	require.NoError(t, err)
 	bodyDecoded, err := url.ParseQuery(string(bodyByes))

--- a/pkg/compliant/schema/version32.go
+++ b/pkg/compliant/schema/version32.go
@@ -26,7 +26,7 @@ func (v responseValidator32) Validate(data io.Reader) []Failure {
 		),
 		"client_secret": validation.Validate(
 			registrationResponse.ClientSecret,
-			validation.Length(1, 36),
+			validation.Length(1, 256),
 		),
 		"redirect_uris": validation.Validate(
 			registrationResponse.RedirectURIs,

--- a/pkg/compliant/step/client_delete.go
+++ b/pkg/compliant/step/client_delete.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	dcr "bitbucket.org/openbankingteam/conformance-dcr/pkg/compliant/client"
 	http2 "bitbucket.org/openbankingteam/conformance-dcr/pkg/http"
 	"fmt"
 	"net/http"
@@ -38,12 +39,10 @@ func (s clientDelete) Run(ctx Context) Result {
 		return NewFailResult(s.stepName, fmt.Sprintf("unable to create request %s: %v", url, err))
 	}
 
-	grantToken, err := ctx.GetGrantToken(s.grantTokenCtxKey)
+	err = dcr.AddRegistrationAccessTokenAuthHeader(req, client)
 	if err != nil {
-		msg := fmt.Sprintf("unable to find client grant token %s in context: %v", s.grantTokenCtxKey, err)
-		return NewFailResult(s.stepName, msg)
+		return NewFailResult(s.stepName, fmt.Sprintf("unable to create request %s: %v", url, err))
 	}
-	req.Header.Set("Authorization", "Bearer "+grantToken.AccessToken)
 
 	debug.Log(http2.DebugRequest(req))
 

--- a/pkg/compliant/step/client_retrieve.go
+++ b/pkg/compliant/step/client_retrieve.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	dcr "bitbucket.org/openbankingteam/conformance-dcr/pkg/compliant/client"
 	http2 "bitbucket.org/openbankingteam/conformance-dcr/pkg/http"
 	"fmt"
 	"net/http"
@@ -38,19 +39,16 @@ func (s clientRetrieve) Run(ctx Context) Result {
 		return NewFailResultWithDebug(s.stepName, msg, debug)
 	}
 
-	grantToken, err := ctx.GetGrantToken(s.grantTokenCtxKey)
-	if err != nil {
-		msg := fmt.Sprintf("unable to find grant token %s in context: %v", s.grantTokenCtxKey, err)
-		return NewFailResultWithDebug(s.stepName, msg, debug)
-	}
-
 	endpoint := fmt.Sprintf("%s/%s", s.registrationEndpoint, client.Id())
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		msg := fmt.Sprintf("unable to make request: %s", err.Error())
 		return NewFailResultWithDebug(s.stepName, msg, debug)
 	}
-	req.Header.Set("Authorization", "Bearer "+grantToken.AccessToken)
+	err = dcr.AddRegistrationAccessTokenAuthHeader(req, client)
+	if err != nil {
+		return NewFailResult(s.stepName, fmt.Sprintf("unable to create request %s: %v", endpoint, err))
+	}
 
 	debug.Log(http2.DebugRequest(req))
 	res, err := s.client.Do(req)

--- a/pkg/compliant/step/client_retrieve_response.go
+++ b/pkg/compliant/step/client_retrieve_response.go
@@ -35,9 +35,20 @@ func (s clientRetrieveResponse) Run(ctx Context) Result {
 		return NewFailResult(s.stepName, "decoding response: "+err.Error())
 	}
 
+	existingClient, err := ctx.GetClient(s.clientCtxKey)
+	if err != nil {
+		return NewFailResult(s.stepName, "failed to get client for key: "+s.responseCtxKey+" from context")
+	}
+
+	// Preserve the registrationAccessToken for future use, the retrieve response will not return it
+	var registrationAccessToken = ""
+	if existingClient != nil && existingClient.RegistrationAccessToken() != "" {
+		registrationAccessToken = existingClient.RegistrationAccessToken()
+	}
+
 	ctx.SetClient(s.clientCtxKey, client.NewClientSecretBasic(
 		registrationResponse.ClientID,
-		registrationResponse.RegistrationAccessToken,
+		registrationAccessToken,
 		registrationResponse.ClientSecret,
 		s.tokenEndpoint,
 	))

--- a/pkg/compliant/step/client_retrieve_response.go
+++ b/pkg/compliant/step/client_retrieve_response.go
@@ -37,6 +37,7 @@ func (s clientRetrieveResponse) Run(ctx Context) Result {
 
 	ctx.SetClient(s.clientCtxKey, client.NewClientSecretBasic(
 		registrationResponse.ClientID,
+		registrationResponse.RegistrationAccessToken,
 		registrationResponse.ClientSecret,
 		s.tokenEndpoint,
 	))


### PR DESCRIPTION
Previously, a token was retrieved using client_credentials grant. According to RFC-7592 then the registration_access_token should be used.

Retrieving the registration_access_token from the registration response and using it in the API interactions

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/613