### PR TITLE
632: SBAT only supports "code id_token" response_types

### DIFF
--- a/pkg/compliant/dcr32_config.go
+++ b/pkg/compliant/dcr32_config.go
@@ -67,7 +67,7 @@ func NewDCR32Config(
 		return DCR32Config{}, errors.Wrap(err, "creating DCR32 config")
 	}
 
-	responseTypes, err := responseTypeResolve(openIDConfig.ResponseTypesSupported)
+	responseTypes, err := responseTypeResolveSbat(openIDConfig.ResponseTypesSupported)
 	if err != nil {
 		return DCR32Config{}, errors.Wrap(err, "creating DCR32 config")
 	}

--- a/pkg/compliant/response_type_resolver.go
+++ b/pkg/compliant/response_type_resolver.go
@@ -28,3 +28,10 @@ func responseTypeResolve(types *[]string) ([]string, error) {
 
 	return responseTypes, nil
 }
+
+// SBAT currently only supports "code id_token"
+func responseTypeResolveSbat(types *[]string) ([]string, error) {
+	var responseTypes []string
+	responseTypes = append(responseTypes, "code id_token")
+	return responseTypes, nil
+}


### PR DESCRIPTION
https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/632