### PR TITLE
613: Setting client_id in negative dcr update test

### DIFF
--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -347,7 +347,7 @@ func DCR32UpdateSoftwareClientWithWrongId(
 		TestCase(
 			NewTestCaseBuilder("Update a deleted software client").
 				WithHttpClient(secureClient).
-				GenerateSignedClaims(authoriserBuilder).
+				GenerateSignedClaimsForRegistrationUpdate(authoriserBuilder).
 				ClientUpdate(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeUnauthorized().
 				Build(),


### PR DESCRIPTION
https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/613