### PR TITLE
613: Allow the registration access token to be overridden

### DIFF
--- a/pkg/compliant/builder.go
+++ b/pkg/compliant/builder.go
@@ -137,19 +137,19 @@ func (t *testCaseBuilder) ClientDelete(registrationEndpoint string) *testCaseBui
 }
 
 func (t *testCaseBuilder) ClientRetrieve(registrationEndpoint string) *testCaseBuilder {
-	nextStep := step.NewClientRetrieve(responseCtxKey, registrationEndpoint, clientCtxKey, grantTokenCtxKey, t.httpClient)
+	nextStep := step.NewClientRetrieve(responseCtxKey, registrationEndpoint, clientCtxKey, "", t.httpClient)
+	t.steps = append(t.steps, nextStep)
+	return t
+}
+
+func (t *testCaseBuilder) ClientRetrieveInvalidRegistrationAccessToken(registrationEndpoint string) *testCaseBuilder {
+	nextStep := step.NewClientRetrieve(responseCtxKey, registrationEndpoint, clientCtxKey, "invalid-access-token-123", t.httpClient)
 	t.steps = append(t.steps, nextStep)
 	return t
 }
 
 func (t *testCaseBuilder) AssertValidSchemaResponse(validator schema.Validator) *testCaseBuilder {
 	nextStep := step.NewClientRetrieveSchema(responseCtxKey, validator)
-	t.steps = append(t.steps, nextStep)
-	return t
-}
-
-func (t *testCaseBuilder) SetInvalidGrantToken() *testCaseBuilder {
-	nextStep := step.NewSetInvalidGrantToken(grantTokenCtxKey)
 	t.steps = append(t.steps, nextStep)
 	return t
 }

--- a/pkg/compliant/builder_test.go
+++ b/pkg/compliant/builder_test.go
@@ -53,10 +53,9 @@ func TestNewTestCaseBuilder(t *testing.T) {
 		ClientDelete(sampleEndpoint).
 		ParseClientRetrieveResponse(sampleEndpoint).
 		AssertValidSchemaResponse(validator).
-		SetInvalidGrantToken().
 		ValidateRegistrationEndpoint(someUrl).
 		GetClientCredentialsGrant(sampleEndpoint)
 
 	assert.Equal(t, "test case", tc.name)
-	assert.Len(t, tc.steps, 16)
+	assert.Len(t, tc.steps, 15)
 }

--- a/pkg/compliant/client/client.go
+++ b/pkg/compliant/client/client.go
@@ -34,6 +34,10 @@ func AddRegistrationAccessTokenAuthHeader(req *http.Request, client Client) erro
 	if client.RegistrationAccessToken() == "" {
 		return errors.New("client has no RegistrationAccessToken")
 	}
-	req.Header.Set("Authorization", "Bearer "+client.RegistrationAccessToken())
+	AddAuthorizationBearerToken(req, client.RegistrationAccessToken())
 	return nil
+}
+
+func AddAuthorizationBearerToken(req *http.Request, accessToken string) {
+	req.Header.Set("Authorization", "Bearer "+accessToken)
 }

--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -271,8 +271,7 @@ func DCR32RetrieveWithInvalidCredentials(
 		TestCase(
 			NewTestCaseBuilder("Retrieve software client with invalid credentials grant").
 				WithHttpClient(secureClient).
-				SetInvalidGrantToken().
-				ClientRetrieve(cfg.OpenIDConfig.RegistrationEndpointAsString()).
+				ClientRetrieveInvalidRegistrationAccessToken(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeUnauthorized().
 				Build(),
 		).


### PR DESCRIPTION
Currently, the registration_access_token from the DCR response will be automatically plugged into subsequent API calls. For negative test cases such as: "Retrieve software client with invalid credentials grant" then we need to be able to supply a bad token.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/613