### PR TITLE
686: Adding test which validates that registration request JWTs with invalid signatures are rejected

### DIFF
--- a/pkg/compliant/builder.go
+++ b/pkg/compliant/builder.go
@@ -87,6 +87,12 @@ func (t *testCaseBuilder) AssertStatusCodeBadRequest() *testCaseBuilder {
 	return t
 }
 
+func (t *testCaseBuilder) AssertErrorMessage(errorCode string, errorMessage string) *testCaseBuilder {
+	nextStep := step.NewAssertErrorMessage(errorCode, errorMessage, responseCtxKey)
+	t.steps = append(t.steps, nextStep)
+	return t
+}
+
 func (t *testCaseBuilder) AssertStatusCodeCreated() *testCaseBuilder {
 	nextStep := step.NewAssertStatus(http.StatusCreated, responseCtxKey)
 	t.steps = append(t.steps, nextStep)

--- a/pkg/compliant/dcr32_test.go
+++ b/pkg/compliant/dcr32_test.go
@@ -16,7 +16,7 @@ func TestNewDCR32(t *testing.T) {
 
 	assert.Equal(t, "1.0", manifest.Version())
 	assert.Equal(t, "DCR32", manifest.Name())
-	assert.Equal(t, 10, len(manifest.Scenarios()))
+	assert.Equal(t, 11, len(manifest.Scenarios()))
 }
 
 func TestDCR32ValidateOIDCConfigRegistrationURL(t *testing.T) {

--- a/pkg/compliant/step/error_message.go
+++ b/pkg/compliant/step/error_message.go
@@ -1,0 +1,48 @@
+package step
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type AssertErrorMessage struct {
+	ErrorCode          string
+	ErrorMessage       string
+	ResponseContextVar string
+	StepName           string
+}
+
+type ErrorResponseBody struct {
+	ErrorCode    string `json:"error"`
+	ErrorMessage string `json:"error_description"`
+}
+
+func NewAssertErrorMessage(errorCode, errorMessage, responseContextVar string) Step {
+	return AssertErrorMessage{
+		errorCode, errorMessage, responseContextVar, fmt.Sprintf("Assert Error Response, error: %s AND error_description: %s", errorCode, errorMessage),
+	}
+}
+
+func (expectedErrorResponse AssertErrorMessage) Run(ctx Context) Result {
+	debug := NewDebug()
+
+	debug.Logf("get response object from ctx var: %s", expectedErrorResponse.ResponseContextVar)
+	r, err := ctx.GetResponse(expectedErrorResponse.ResponseContextVar)
+	if err != nil {
+		return NewFailResult(expectedErrorResponse.StepName, fmt.Sprintf("getting response object from context: %s", err.Error()))
+	}
+
+	var actualErrorResponse ErrorResponseBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err = decoder.Decode(&actualErrorResponse); err != nil {
+		return NewFailResult(expectedErrorResponse.StepName, "decoding response: "+err.Error())
+	}
+	if actualErrorResponse.ErrorCode != expectedErrorResponse.ErrorCode {
+		return NewFailResult(expectedErrorResponse.StepName, fmt.Sprintf("Invalid error response, expected error: %s, got error: %s", expectedErrorResponse.ErrorCode, actualErrorResponse.ErrorCode))
+	}
+	if actualErrorResponse.ErrorMessage != expectedErrorResponse.ErrorMessage {
+		return NewFailResult(expectedErrorResponse.StepName, fmt.Sprintf("Invalid error response, expected error_description: %s, got error_description: %s", expectedErrorResponse.ErrorMessage, actualErrorResponse.ErrorMessage))
+	}
+	return NewPassResultWithDebug(expectedErrorResponse.StepName, debug)
+}


### PR DESCRIPTION
Adding test which validates that registration request JWTs with invalid signatures are rejected.

The test generates an RSA Private Key to sign the message with, which produces a valid signed JWT. The JWT header kid will point to the OBSeal in the JWKS for this software statement, however we will not have used the OBSeal to sign the JWT, therefore signature validation must fail when verified against the OBSeal.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/686