### PR TITLE
655: Adding test case to check that registration redirect_uri must be in software_redirect_uris

### DIFF
--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -220,6 +220,15 @@ func DCR32CreateInvalidRegistrationRequest(
 				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeBadRequest().
 				Build(),
+		).
+		TestCase(
+			NewTestCaseBuilder("Register software client fails on redirect_uri not in software_redirect_uris").
+				WithHttpClient(secureClient).
+				GenerateSignedClaims(authoriserBuilder.WithRedirectURIs([]string{"https://abc.com"})).
+				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
+				AssertStatusCodeBadRequest().
+				AssertErrorMessage("invalid_redirect_uri", "invalid registration request redirect_uris value, must match or be a subset of the software_statement.redirect_uris").
+				Build(),
 		).Build()
 }
 


### PR DESCRIPTION
https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/655