### PR TITLE
693: Automate building docker image

### DIFF
--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -1,0 +1,38 @@
+name: Build and Test Image
+
+on:
+  push:
+    branches:
+      - sbat-master
+    paths-ignore:
+      - README.md
+
+env:
+  PR_NUMBER: pr-${{ github.event.number }}
+  SPEC_IMAGE: conformance-dcr
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Auth GCloud GCR
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCR_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+      
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker
+      
+      - name: Build & Push Docker Image
+        run: |
+          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} .
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:latest
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }}
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:latest

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -8,7 +8,6 @@ on:
       - README.md
 
 env:
-  PR_NUMBER: pr-${{ github.event.number }}
   SPEC_IMAGE: conformance-dcr
 
 jobs:

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Build & Push Docker Image
         run: |
-          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} .
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking//${{ env.SPEC_IMAGE }}:latest
+          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} .
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:latest
           docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:${{ env.GITHUB_REF }}
           docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SPEC_IMAGE }}:latest

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -1,4 +1,4 @@
-name: Build and Test Image
+name: Build and Push Image
 
 on:
   push:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PR_NUMBER: pr-${{ github.event.number }}
-  SPEC_IMAGE: uk-conformance-dcr
+  IMAGE_REPO: securebanking/tests/uk-conformance-dcr
 
 jobs:
   check:
@@ -62,7 +62,7 @@ jobs:
       - name: 'Run Conformance-DCR Tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v SPEC_IMAGE=${{ env.SPEC_IMAGE }} -v TAG=${{ env.PR_NUMBER }}'
+          args: '-v IMAGE_REPO=${{ env.IMAGE_REPO }} -v TAG=${{ env.PR_NUMBER }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dcr-conformance-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}


### PR DESCRIPTION
New workflow for building image on push to sbat-master

Image will push to [main repo](https://console.cloud.google.com/gcr/images/sbat-gcr-develop/eu/securebanking/conformance-dcr?project=sbat-gcr-develop&supportedpurview=project)

With the github ref & latest tag (versioning can be added in at a later date)

For the PR workflow images will push to [test repo](https://console.cloud.google.com/gcr/images/sbat-gcr-develop/eu/securebanking/tests/uk-conformance-dcr?project=sbat-gcr-develop&supportedpurview=project) and are 'throw away' (Can look into clearing down old images in this location)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/693