### PR TITLE
693: Automate building docker image

### DIFF
--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   SPEC_IMAGE: conformance-dcr
+  GITHUB_SHA: ${{ github.sha }}
 
 jobs:
   build:

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   SPEC_IMAGE: conformance-dcr
-  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.sha }}
 
 jobs:
   build:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -66,5 +66,5 @@ jobs:
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dcr-conformance-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          TRIGGER_NAME: 'empty'
+          TRIGGER_NAME: 'manual'
         id: run-tests

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -52,8 +52,8 @@ jobs:
       
       - name: Build & Push Docker Image
         run: |
-          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/tests/${{ env.SPEC_IMAGE }}:${{ env.PR_NUMBER }} .
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/tests/${{ env.SPEC_IMAGE }}:${{ env.PR_NUMBER }}
+          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.DEV_REPO }}/${{ env.IMAGE_REPO }}:${{ env.PR_NUMBER }} .
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/${{ env.IMAGE_REPO }}:${{ env.PR_NUMBER }}
   test:
     runs-on: ubuntu-latest
     name: Test Image

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -66,4 +66,5 @@ jobs:
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dcr-conformance-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          TRIGGER_NAME: 'empty'
         id: run-tests

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -66,5 +66,5 @@ jobs:
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dcr-conformance-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          TRIGGER_NAME: 'manual'
+          TRIGGER_NAME: 'temp-trigger'
         id: run-tests


### PR DESCRIPTION
**Missed a env var**

New workflow for building image on push to sbat-master

Image will push to [main repo](https://console.cloud.google.com/gcr/images/sbat-gcr-develop/eu/securebanking/conformance-dcr?project=sbat-gcr-develop&supportedpurview=project)

With the github ref & latest tag (versioning can be added in at a later date)

For the PR workflow images will push to [test repo](https://console.cloud.google.com/gcr/images/sbat-gcr-develop/eu/securebanking/tests/uk-conformance-dcr?project=sbat-gcr-develop&supportedpurview=project) and are 'throw away' (Can look into clearing down old images in this location)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/693