### PR TITLE
739: Fixing bug in building the authoriser for different token_endpoint_auth_methods

### DIFF
--- a/pkg/compliant/auth/authoriser.go
+++ b/pkg/compliant/auth/authoriser.go
@@ -100,7 +100,19 @@ func NewAuthoriser(
 	return none{}
 }
 
-func createNewPrivateKeyJwtClient(config openid.Configuration, ssa string, aud string, kid string, issuer string, tokenEndpointSignMethod jwt.SigningMethod, redirectURIs []string, responseTypes []string, privateKey *rsa.PrivateKey, jwtExpiration time.Duration, transportCert *x509.Certificate, transportSubjectDn string, requestObjectSignAlg string, clientId string) Authoriser {
+func createNewPrivateKeyJwtClient(
+	config openid.Configuration,
+	ssa string, aud string, kid string, issuer string,
+	tokenEndpointSignMethod jwt.SigningMethod,
+	redirectURIs []string,
+	responseTypes []string,
+	privateKey *rsa.PrivateKey,
+	jwtExpiration time.Duration,
+	transportCert *x509.Certificate,
+	transportSubjectDn string,
+	requestObjectSignAlg string,
+	clientId string,
+) Authoriser {
 	return NewClientPrivateKeyJwt(
 		config.TokenEndpoint,
 		tokenEndpointSignMethod,
@@ -124,7 +136,19 @@ func createNewPrivateKeyJwtClient(config openid.Configuration, ssa string, aud s
 	)
 }
 
-func createNewTlsClientAuth(config openid.Configuration, ssa string, aud string, kid string, issuer string, tokenEndpointSignMethod jwt.SigningMethod, redirectURIs []string, responseTypes []string, privateKey *rsa.PrivateKey, jwtExpiration time.Duration, transportCert *x509.Certificate, transportSubjectDn string, requestObjectSignAlg string, clientId string) Authoriser {
+func createNewTlsClientAuth(
+	config openid.Configuration,
+	ssa string, aud string, kid string, issuer string,
+	tokenEndpointSignMethod jwt.SigningMethod,
+	redirectURIs []string,
+	responseTypes []string,
+	privateKey *rsa.PrivateKey,
+	jwtExpiration time.Duration,
+	transportCert *x509.Certificate,
+	transportSubjectDn string,
+	requestObjectSignAlg string,
+	clientId string,
+) Authoriser {
 	return NewTlsClientAuth(
 		config.TokenEndpoint,
 		NewJwtSigner(

--- a/pkg/compliant/auth/authoriser.go
+++ b/pkg/compliant/auth/authoriser.go
@@ -36,73 +36,24 @@ func NewAuthoriser(
 
 	if preferredTokenEndpointAuthMethod != "" {
 		if sliceContains(preferredTokenEndpointAuthMethod, config.TokenEndpointAuthMethodsSupported) {
-			return NewClientPrivateKeyJwt(
-				config.TokenEndpoint,
-				tokenEndpointSignMethod,
-				privateKey,
-				NewJwtSigner(
-					tokenEndpointSignMethod,
-					ssa,
-					issuer,
-					aud,
-					kid,
-					preferredTokenEndpointAuthMethod,
-					requestObjectSignAlg,
-					redirectURIs,
-					responseTypes,
-					privateKey,
-					jwtExpiration,
-					transportCert,
-					transportSubjectDn,
-					clientId,
-				),
-			)
+			if preferredTokenEndpointAuthMethod == "tls_client_auth" {
+				return createNewTlsClientAuth(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs,
+					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+			}
+			if preferredTokenEndpointAuthMethod == "private_key_jwt" {
+				return createNewPrivateKeyJwtClient(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs,
+					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+			}
 		}
 	}
 
 	if sliceContains("tls_client_auth", config.TokenEndpointAuthMethodsSupported) {
-		return NewTlsClientAuth(
-			config.TokenEndpoint,
-			NewJwtSigner(
-				tokenEndpointSignMethod,
-				ssa,
-				issuer,
-				aud,
-				kid,
-				"tls_client_auth",
-				requestObjectSignAlg,
-				redirectURIs,
-				responseTypes,
-				privateKey,
-				jwtExpiration,
-				transportCert,
-				transportSubjectDn,
-				clientId,
-			),
-		)
+		return createNewTlsClientAuth(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs, responseTypes,
+			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
 	}
 	if sliceContains("private_key_jwt", config.TokenEndpointAuthMethodsSupported) {
-		return NewClientPrivateKeyJwt(
-			config.TokenEndpoint,
-			tokenEndpointSignMethod,
-			privateKey,
-			NewJwtSigner(
-				tokenEndpointSignMethod,
-				ssa,
-				issuer,
-				aud,
-				kid,
-				"private_key_jwt",
-				requestObjectSignAlg,
-				redirectURIs,
-				responseTypes,
-				privateKey,
-				jwtExpiration,
-				transportCert,
-				transportSubjectDn,
-				clientId,
-			),
-		)
+		return createNewPrivateKeyJwtClient(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs, responseTypes,
+			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
 	}
 	if sliceContains("client_secret_jwt", config.TokenEndpointAuthMethodsSupported) {
 		return NewClientSecretJWT(
@@ -147,6 +98,52 @@ func NewAuthoriser(
 		)
 	}
 	return none{}
+}
+
+func createNewPrivateKeyJwtClient(config openid.Configuration, ssa string, aud string, kid string, issuer string, tokenEndpointSignMethod jwt.SigningMethod, redirectURIs []string, responseTypes []string, privateKey *rsa.PrivateKey, jwtExpiration time.Duration, transportCert *x509.Certificate, transportSubjectDn string, requestObjectSignAlg string, clientId string) Authoriser {
+	return NewClientPrivateKeyJwt(
+		config.TokenEndpoint,
+		tokenEndpointSignMethod,
+		privateKey,
+		NewJwtSigner(
+			tokenEndpointSignMethod,
+			ssa,
+			issuer,
+			aud,
+			kid,
+			"private_key_jwt",
+			requestObjectSignAlg,
+			redirectURIs,
+			responseTypes,
+			privateKey,
+			jwtExpiration,
+			transportCert,
+			transportSubjectDn,
+			clientId,
+		),
+	)
+}
+
+func createNewTlsClientAuth(config openid.Configuration, ssa string, aud string, kid string, issuer string, tokenEndpointSignMethod jwt.SigningMethod, redirectURIs []string, responseTypes []string, privateKey *rsa.PrivateKey, jwtExpiration time.Duration, transportCert *x509.Certificate, transportSubjectDn string, requestObjectSignAlg string, clientId string) Authoriser {
+	return NewTlsClientAuth(
+		config.TokenEndpoint,
+		NewJwtSigner(
+			tokenEndpointSignMethod,
+			ssa,
+			issuer,
+			aud,
+			kid,
+			"tls_client_auth",
+			requestObjectSignAlg,
+			redirectURIs,
+			responseTypes,
+			privateKey,
+			jwtExpiration,
+			transportCert,
+			transportSubjectDn,
+			clientId,
+		),
+	)
 }
 
 func sliceContains(value string, list []string) bool {

--- a/pkg/compliant/schema/version32.go
+++ b/pkg/compliant/schema/version32.go
@@ -87,7 +87,7 @@ func (v responseValidator32) Validate(data io.Reader) []Failure {
 		),
 		"tls_client_auth_subject_dn": validation.Validate(
 			registrationResponse.TLSClientAuthSubjectDn,
-			validation.Length(1, 128),
+			validation.Length(1, 256),
 		),
 	}
 	failures = append(failures, toFailures(errs)...)

--- a/pkg/compliant/schema/version33.go
+++ b/pkg/compliant/schema/version33.go
@@ -93,7 +93,7 @@ func (v responseValidator33) Validate(data io.Reader) []Failure {
 		),
 		"tls_client_auth_subject_dn": validation.Validate(
 			registrationResponse.TLSClientAuthSubjectDn,
-			validation.Length(1, 128),
+			validation.Length(1, 256),
 		),
 	}
 	failures = append(failures, toFailures(errs)...)


### PR DESCRIPTION
The logic for building the authoriser based on the preferredTokenEndpointAuthMethod config was hardcoded for private_key_jwt.

Fixed this logic to support tls_client_auth as well. Other auth methods are not supported as they are not FAPI compliant.

https://github.com/SecureApiGateway/SecureApiGateway/issues/739