### PR TITLE
811: Set expected error messages

### DIFF
--- a/pkg/compliant/auth/authoriser_builder.go
+++ b/pkg/compliant/auth/authoriser_builder.go
@@ -100,6 +100,11 @@ func (b AuthoriserBuilder) WithClientId(clientId string) AuthoriserBuilder {
 	return b
 }
 
+func (b AuthoriserBuilder) WithTokenEndpointSigningMethod(tokenEndpointSignMethod *jwt.SigningMethodHMAC) AuthoriserBuilder {
+	b.tokenEndpointSignMethod = tokenEndpointSignMethod
+	return b
+}
+
 func (b AuthoriserBuilder) Build() (Authoriser, error) {
 	if b.ssa == "" {
 		return none{}, errors.New("missing ssa from authoriser")

--- a/pkg/compliant/builder.go
+++ b/pkg/compliant/builder.go
@@ -75,6 +75,12 @@ func (t *testCaseBuilder) AssertStatusCodeOk() *testCaseBuilder {
 	return t
 }
 
+func (t *testCaseBuilder) OutputTransactionId() *testCaseBuilder {
+	nextStep := step.OutputTransactionId(responseCtxKey)
+	t.steps = append(t.steps, nextStep)
+	return t
+}
+
 func (t *testCaseBuilder) AssertStatusCodeUnauthorized() *testCaseBuilder {
 	nextStep := step.NewAssertStatus(http.StatusUnauthorized, responseCtxKey)
 	t.steps = append(t.steps, nextStep)

--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -452,18 +452,20 @@ func DCR32RegistrationRequestInvalidSignature(
 				GenerateSignedClaims(authoriserBuilder).
 				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeBadRequest().
-				AssertErrorMessage("invalid_client_metadata", "registration JWT signature invalid").
+				AssertErrorMessage("invalid_client_metadata", "Registration Request signature is invalid").
 				Build(),
 		).
-		TestCase(
-			NewTestCaseBuilder("Register software client signed with unsupported alg none").
-				WithHttpClient(secureClient).
-				GenerateSignedClaims(authoriserBuilder.WithPreferredTokenEndpointAuthMethod("none")).
-				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
-				AssertStatusCodeBadRequest().
-				AssertErrorMessage("invalid_client_metadata", "registration JWT signature invalid").
-				Build(),
-		).
+		// ToDo: This doesn't fail as expected as the jwt is not actually signed usign teh tokenEndpointSignMethod
+		//TestCase(
+		//		NewTestCaseBuilder("Register software client signed with unsupported alg none").
+		//			WithHttpClient(secureClient).
+		//			GenerateSignedClaims(authoriserBuilder.WithTokenEndpointSigningMethod(jwt.SigningMethodHS256)).
+		//			PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
+		//			OutputTransactionId().
+		//			AssertStatusCodeBadRequest().
+		//			AssertErrorMessage("invalid_client_metadata", "registration JWT signature invalid").
+		//			Build(),
+		//	).
 		Build(), nil
 }
 
@@ -512,7 +514,7 @@ func DCR32RegisterInvalidSoftwareStatementSigning(
 				).
 				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeBadRequest().
-				AssertErrorMessage("invalid_software_statement", "software_statement signature is invalid").
+				AssertErrorMessage("invalid_software_statement", "Failed to validate SSA against jwks_uri").
 				Build(),
 		).
 		TestCase(
@@ -523,7 +525,7 @@ func DCR32RegisterInvalidSoftwareStatementSigning(
 				).
 				PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
 				AssertStatusCodeBadRequest().
-				AssertErrorMessage("invalid_software_statement", "software_statement is not a valid JWT").
+				AssertErrorMessage("invalid_software_statement", "Software Statement JWT error: Failed to reconstruct jwt from b64 encoded jwt string").
 				Build(),
 		).
 		Build(), nil

--- a/pkg/compliant/step/error_message.go
+++ b/pkg/compliant/step/error_message.go
@@ -3,6 +3,7 @@ package step
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type AssertErrorMessage struct {
@@ -41,7 +42,7 @@ func (expectedErrorResponse AssertErrorMessage) Run(ctx Context) Result {
 	if actualErrorResponse.ErrorCode != expectedErrorResponse.ErrorCode {
 		return NewFailResult(expectedErrorResponse.StepName, fmt.Sprintf("Invalid error response, expected error: %s, got error: %s", expectedErrorResponse.ErrorCode, actualErrorResponse.ErrorCode))
 	}
-	if actualErrorResponse.ErrorMessage != expectedErrorResponse.ErrorMessage {
+	if !strings.Contains(actualErrorResponse.ErrorMessage, expectedErrorResponse.ErrorMessage) {
 		return NewFailResult(expectedErrorResponse.StepName, fmt.Sprintf("Invalid error response, expected error_description: %s, got error_description: %s", expectedErrorResponse.ErrorMessage, actualErrorResponse.ErrorMessage))
 	}
 	return NewPassResultWithDebug(expectedErrorResponse.StepName, debug)

--- a/pkg/compliant/step/transaction_id.go
+++ b/pkg/compliant/step/transaction_id.go
@@ -1,0 +1,34 @@
+package step
+
+import (
+	"fmt"
+)
+
+type outputTransactionId struct {
+	code               int
+	responseContextVar string
+	stepName           string
+}
+
+/**
+May be used as part of a test case to output the x-fapi-interaction-id for debug purposes
+*/
+func OutputTransactionId(responseContextVar string) Step {
+	return outputTransactionId{
+		responseContextVar: responseContextVar,
+		stepName:           fmt.Sprintf("Output x-fapi-interaction-id"),
+	}
+}
+
+func (a outputTransactionId) Run(ctx Context) Result {
+	debug := NewDebug()
+
+	debug.Logf("get response object from ctx var: %s", a.responseContextVar)
+	r, err := ctx.GetResponse(a.responseContextVar)
+	if err != nil {
+		return NewFailResult(a.stepName, fmt.Sprintf("getting response object from context: %s", err.Error()))
+	}
+	transactionId := r.Header.Get("x-fapi-interaction-id")
+	debug.Logf("x-fapi-interaction-id: %s", transactionId)
+	return NewPassResultWithDebug(a.stepName, debug)
+}


### PR DESCRIPTION
Also added a step that can be used to output the x-fapi-interaction-id of a response - handy when debugging and wanting to view logs in gcp for a failing test case

One test is commented out and will need fixing at some point. A test to check that if the registration jwt is signed using an unapproved algorithm then we see a failure.

Issue: https://github.com/secureapigateway/secureapigateway/issues/811