### PR TITLE
861: FAIL conditions output x-fapi-interaction-id

### DIFF
--- a/pkg/compliant/dcr32.go
+++ b/pkg/compliant/dcr32.go
@@ -100,6 +100,7 @@ func DCR32CreateSoftwareClientTestCases(
 			WithHttpClient(secureClient).
 			GenerateSignedClaims(authoriserBuilder).
 			PostClientRegister(cfg.OpenIDConfig.RegistrationEndpointAsString()).
+			OutputTransactionId().
 			AssertStatusCodeCreated().
 			ParseClientRegisterResponse(authoriserBuilder).
 			Build(),

--- a/pkg/compliant/step/client_delete.go
+++ b/pkg/compliant/step/client_delete.go
@@ -54,7 +54,8 @@ func (s clientDelete) Run(ctx Context) Result {
 	debug.Log(http2.DebugResponse(res))
 
 	if res.StatusCode != http.StatusNoContent {
-		message := fmt.Sprintf("unexpected status code %d, should be %d", res.StatusCode, http.StatusNoContent)
+		message := fmt.Sprintf("unexpected status code %d, should be %d. x-fapi-interaction-id %s",
+			res.StatusCode, http.StatusNoContent, res.Header.Get("x-fapi-interaction-id"))
 		return NewFailResultWithDebug(s.stepName, message, debug)
 	}
 

--- a/pkg/compliant/step/client_retrieve.go
+++ b/pkg/compliant/step/client_retrieve.go
@@ -59,7 +59,8 @@ func (s clientRetrieve) Run(ctx Context) Result {
 	debug.Log(http2.DebugRequest(req))
 	res, err := s.client.Do(req)
 	if err != nil {
-		msg := fmt.Sprintf("unable to call endpoint %s: %v", endpoint, err)
+		msg := fmt.Sprintf("unable to call endpoint %s: %v. x-fapi-interaction-id: %s", endpoint, err,
+			res.Header.Get("x-fapi-interaction-id"))
 		return NewFailResultWithDebug(s.stepName, msg, debug)
 	}
 

--- a/pkg/compliant/step/error_message.go
+++ b/pkg/compliant/step/error_message.go
@@ -20,7 +20,8 @@ type ErrorResponseBody struct {
 
 func NewAssertErrorMessage(errorCode, errorMessage, responseContextVar string) Step {
 	return AssertErrorMessage{
-		errorCode, errorMessage, responseContextVar, fmt.Sprintf("Assert Error Response, error: %s AND error_description: %s", errorCode, errorMessage),
+		errorCode, errorMessage, responseContextVar,
+		fmt.Sprintf("Assert Error Response, error: %s AND error_description: %s", errorCode, errorMessage),
 	}
 }
 

--- a/pkg/compliant/step/status_code.go
+++ b/pkg/compliant/step/status_code.go
@@ -32,7 +32,8 @@ func (a assertStatusCode) Run(ctx Context) Result {
 		debug.Log(http.DebugResponse(r))
 		return NewFailResultWithDebug(
 			a.stepName,
-			fmt.Sprintf("Expecting status code %d but got %d", a.code, r.StatusCode),
+			fmt.Sprintf("Expecting status code %d but got %d. x-fapi-interaction-id: %s", a.code, r.StatusCode,
+				r.Header.Get("x-fapi-interaction-id")),
 			debug,
 		)
 	}


### PR DESCRIPTION
Some FAIL conditions now output the interaction-id so SAPIG log entries associated with a FAIL condition may be found easily.

Issue: https://github.com/secureapigateway/secureapigateway/issues/861