### PR TITLE
1179: Fixing test issues

### DIFF
--- a/pkg/compliant/step/client_delete_test.go
+++ b/pkg/compliant/step/client_delete_test.go
@@ -57,7 +57,7 @@ func TestNewClientDelete_Expects204(t *testing.T) {
 	result := step.Run(ctx)
 
 	assert.False(t, result.Pass)
-	assert.Equal(t, "unexpected status code 200, should be 204", result.FailReason)
+	assert.Contains(t, result.FailReason, "unexpected status code 200, should be 204")
 }
 
 func TestNewClientDelete_HandlesCreateRequestError(t *testing.T) {

--- a/pkg/compliant/step/client_retrieve.go
+++ b/pkg/compliant/step/client_retrieve.go
@@ -59,8 +59,11 @@ func (s clientRetrieve) Run(ctx Context) Result {
 	debug.Log(http2.DebugRequest(req))
 	res, err := s.client.Do(req)
 	if err != nil {
-		msg := fmt.Sprintf("unable to call endpoint %s: %v. x-fapi-interaction-id: %s", endpoint, err,
-			res.Header.Get("x-fapi-interaction-id"))
+		fapiInteractionId := ""
+		if res != nil {
+			fapiInteractionId = res.Header.Get("x-fapi-interaction-id")
+		}
+		msg := fmt.Sprintf("unable to call endpoint %s: %v. x-fapi-interaction-id: %s", endpoint, err, fapiInteractionId)
 		return NewFailResultWithDebug(s.stepName, msg, debug)
 	}
 

--- a/pkg/compliant/step/client_retrieve_test.go
+++ b/pkg/compliant/step/client_retrieve_test.go
@@ -64,10 +64,10 @@ func TestNewClientRegister_HandlesExecuteRequestError(t *testing.T) {
 	result := step.Run(ctx)
 
 	assert.False(t, result.Pass)
-	assert.Equal(
+	assert.Contains(
 		t,
-		"unable to call endpoint localhost/foo: Get \"localhost/foo\": unsupported protocol scheme \"\"",
 		result.FailReason,
+		"unable to call endpoint localhost/foo: Get \"localhost/foo\": unsupported protocol scheme \"",
 	)
 }
 

--- a/pkg/compliant/step/status_code_test.go
+++ b/pkg/compliant/step/status_code_test.go
@@ -36,5 +36,5 @@ func TestAssertStatusOk_FailsIfStatusCodeIsOtherThenOk(t *testing.T) {
 	result := step.Run(ctx)
 
 	assert.False(t, result.Pass)
-	assert.Equal(t, "Expecting status code 200 but got 418", result.FailReason)
+	assert.Contains(t, result.FailReason, "Expecting status code 200 but got 418")
 }


### PR DESCRIPTION
As part of investigating the pipeline failures, we noticed that the unit tests were also failing, fixing these to be able to investigate the pipeline failures.

Test failures were introduced by PR:
https://github.com/SecureApiGateway/conformance-dcr/pull/29

Fixes:
- Resolved seg fault issue in the unit tests due to trying to extract the x-fapi-interaction-id from the header of a nil Response object.
- Improved test assertions to work with new error messages which include the x-fapi-interaction-id

https://github.com/SecureApiGateway/SecureApiGateway/issues/1179