### PR TITLE
987: Move to Artifact Registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,5 @@ jobs:
         run: make tools
       - name: Build
         run: make build
-      # step disable unit fix: https://github.com/secureapigateway/secureapigateway/issues/928
-      #- name: Test
-      #  run: make test
+      - name: Test
+        run: make test

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Authenticate GCP
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -25,7 +25,7 @@ jobs:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
       
       - name: Auth Docker
         run: |

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Authenticate GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 

--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Auth GCloud GCR
+      - name: Authenticate GCP
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
@@ -27,12 +27,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       
-      - name: Configure Docker
+      - name: Auth Docker
         run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build & Push Docker Image
         run: |
-          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GITHUB_REF }} .
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GITHUB_REF }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}
+          docker build --file Dockerfile-sbat -t ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GITHUB_REF }} -t ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest .
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Authenticate GCP
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -45,7 +45,7 @@ jobs:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
       
       - name: Auth Docker
         run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -1,5 +1,5 @@
 name: build_and_test
-run-name: Build and test image
+run-name: Build and Test Image
 on:
   pull_request:
     branches:
@@ -29,9 +29,8 @@ jobs:
         run: make tools
       - name: Build
         run: make build
-      # step disable unit fix: https://github.com/secureapigateway/secureapigateway/issues/928
-      #- name: Test
-      #  run: make test
+      - name: Test
+        run: make test
   build:
     runs-on: ubuntu-latest
     name: Build Image
@@ -40,7 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Auth GCloud GCR
+      - name: Authenticate GCP
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
@@ -48,14 +47,14 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       
-      - name: Configure Docker
+      - name: Auth Docker
         run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build & Push Docker Image
         run: |
-          docker build --file Dockerfile-sbat -t eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/tests/${{ env.SERVICE_NAME }}:${{ env.PR_NUMBER }} .
-          docker push eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/tests/${{ env.SERVICE_NAME }}:${{ env.PR_NUMBER }}
+          docker build --file Dockerfile-sbat -t ${{ vars.GAR_DEV_REPO }}/securebanking/pr/${{ env.SERVICE_NAME }}:${{ env.PR_NUMBER }} .
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/pr/${{ env.SERVICE_NAME }}:${{ env.PR_NUMBER }}
   test:
     runs-on: ubuntu-latest
     name: Test Image
@@ -64,7 +63,7 @@ jobs:
       - name: 'Run Conformance-DCR Tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v IMAGE_REPO=securebanking/tests/${{ env.SERVICE_NAME }} -v TAG=${{ env.PR_NUMBER }}'
+          args: '-v IMAGE_REPO=securebanking/pr/${{ env.SERVICE_NAME }} -v TAG=${{ env.PR_NUMBER }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dev-dcr-conformance-tests'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Authenticate GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       SERVICE_NAME: tests/uk-conformance-dcr
       with_maven: false
     secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
+      GCR_CREDENTIALS_JSON: ${{ secrets.DEV_GAR_KEY }}
       GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
 
   release_draft_no_pr:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build_image: ## build the docker image. Use available args IMAGE_TAG=v1.x.y, ENA
 
 .PHONY: build_sbat_image
 build_sbat_image: ## build the docker image. Use available args IMAGE_TAG=v1.x.y
-	docker build --file Dockerfile-sbat ${DOCKER_BUILD_ARGS} -t "eu.gcr.io/sbat-gcr-develop/securebanking/conformance-dcr:${IMAGE_TAG}" .
+	docker build --file Dockerfile-sbat ${DOCKER_BUILD_ARGS} -t "europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/conformance-dcr:${IMAGE_TAG}" .
 
 ##@ Dependencies:
 
@@ -96,10 +96,9 @@ lint_fix: ## Basic linting and vetting of code with fix option enabled
 	golangci-lint run --fix --config ./.golangci.yml ./...
 
 # docker
-name := tests/uk-conformance-dcr
-repo := sbat-gcr-develop
+name := pr/uk-conformance-dcr
 tag := latest
 
 docker:
-	docker build --file Dockerfile-sbat -t eu.gcr.io/${repo}/securebanking/${name}:${tag} .
-	docker push eu.gcr.io/${repo}/securebanking/${name}:${tag}
+	docker build --file Dockerfile-sbat -t europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/${name}:${tag} .
+	docker push europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/${name}:${tag}

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build_sbat_image: ## build the docker image. Use available args IMAGE_TAG=v1.x.y
 .PHONY: tools
 tools: ## install go tools (goimports, golangci-lint)
 	@echo -e "\033[92m  ---> Installing Go Tools ... \033[0m"
-	go get -u golang.org/x/tools/cmd/goimports
+	go get -u golang.org/x/tools/cmd/goimports@v0.14.0
 	@printf "%b" "\033[93m" "  ---> Installing golangci-lint@v1.16.0 (https://github.com/golangci/golangci-lint) ... " "\033[0m" "\n"
 	curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(shell go env GOPATH)/bin v1.21.0
 


### PR DESCRIPTION
- Enable tests again as previous [issue](https://github.com/secureapigateway/secureapigateway/issues/928) is marked as  fixed
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry

Issue: 
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202