### PR TITLE
1390: Create OAuth2.0 clients which support JARM

### DIFF
--- a/pkg/compliant/dcr32_config.go
+++ b/pkg/compliant/dcr32_config.go
@@ -67,7 +67,7 @@ func NewDCR32Config(
 		return DCR32Config{}, errors.Wrap(err, "creating DCR32 config")
 	}
 
-	responseTypes, err := responseTypeResolveSbat(openIDConfig.ResponseTypesSupported)
+	responseTypes, err := responseTypeResolve(openIDConfig.ResponseTypesSupported)
 	if err != nil {
 		return DCR32Config{}, errors.Wrap(err, "creating DCR32 config")
 	}

--- a/pkg/compliant/response_type_resolver.go
+++ b/pkg/compliant/response_type_resolver.go
@@ -28,10 +28,3 @@ func responseTypeResolve(types *[]string) ([]string, error) {
 
 	return responseTypes, nil
 }
-
-// SBAT currently only supports "code id_token"
-func responseTypeResolveSbat(types *[]string) ([]string, error) {
-	var responseTypes []string
-	responseTypes = append(responseTypes, "code id_token")
-	return responseTypes, nil
-}


### PR DESCRIPTION
DCR request needs to include "code" as one of the response_types values to use JARM.

Using the default response_types resolver method which registers all response_types supported by the AS. All environments where the AS has been configured to support JARM will now be able to use the DCR pipeline to create registrations that can use the functionality.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1390