### PR TITLE
1390: Support configuring authorization_signed_response_alg DCR param

### DIFF
--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Brand                            string   `json:"brand"`
 	PreferredTokenEndPointAuthMethod string   `json:"preferred_token_endpoint_auth_method"`
 	CreateSoftwareClientOnly         bool     `json:"create_software_client_only"`
+	AuthorizationSignedResponseAlg   string   `json:"authorization_signed_response_alg"`
 }
 
 func LoadConfig(configFilePath string) (Config, error) {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -85,6 +85,7 @@ func runCmd(flags flags) {
 		cfg.SpecVersion,
 		cfg.PreferredTokenEndPointAuthMethod,
 		cfg.CreateSoftwareClientOnly,
+		cfg.AuthorizationSignedResponseAlg,
 	)
 	exitOnError(err)
 

--- a/pkg/compliant/auth/authoriser.go
+++ b/pkg/compliant/auth/authoriser.go
@@ -28,6 +28,7 @@ func NewAuthoriser(
 	transportSubjectDn string,
 	preferredTokenEndpointAuthMethod string,
 	clientId string,
+	authorizationSignedResponseAlg string,
 ) Authoriser {
 	requestObjectSignAlg := "none"
 	if len(config.RequestObjectSignAlgSupported) > 0 {
@@ -38,22 +39,24 @@ func NewAuthoriser(
 		if sliceContains(preferredTokenEndpointAuthMethod, config.TokenEndpointAuthMethodsSupported) {
 			if preferredTokenEndpointAuthMethod == "tls_client_auth" {
 				return createNewTlsClientAuth(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs,
-					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg,
+					clientId, authorizationSignedResponseAlg)
 			}
 			if preferredTokenEndpointAuthMethod == "private_key_jwt" {
 				return createNewPrivateKeyJwtClient(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs,
-					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+					responseTypes, privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg,
+					clientId, authorizationSignedResponseAlg)
 			}
 		}
 	}
 
 	if sliceContains("tls_client_auth", config.TokenEndpointAuthMethodsSupported) {
 		return createNewTlsClientAuth(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs, responseTypes,
-			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId, authorizationSignedResponseAlg)
 	}
 	if sliceContains("private_key_jwt", config.TokenEndpointAuthMethodsSupported) {
 		return createNewPrivateKeyJwtClient(config, ssa, aud, kid, issuer, tokenEndpointSignMethod, redirectURIs, responseTypes,
-			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId)
+			privateKey, jwtExpiration, transportCert, transportSubjectDn, requestObjectSignAlg, clientId, authorizationSignedResponseAlg)
 	}
 	if sliceContains("client_secret_jwt", config.TokenEndpointAuthMethodsSupported) {
 		return NewClientSecretJWT(
@@ -73,6 +76,7 @@ func NewAuthoriser(
 				transportCert,
 				transportSubjectDn,
 				clientId,
+				authorizationSignedResponseAlg,
 			),
 		)
 	}
@@ -94,6 +98,7 @@ func NewAuthoriser(
 				transportCert,
 				transportSubjectDn,
 				clientId,
+				authorizationSignedResponseAlg,
 			),
 		)
 	}
@@ -112,6 +117,7 @@ func createNewPrivateKeyJwtClient(
 	transportSubjectDn string,
 	requestObjectSignAlg string,
 	clientId string,
+	authorizationSignedResponseAlg string,
 ) Authoriser {
 	return NewClientPrivateKeyJwt(
 		config.TokenEndpoint,
@@ -132,6 +138,7 @@ func createNewPrivateKeyJwtClient(
 			transportCert,
 			transportSubjectDn,
 			clientId,
+			authorizationSignedResponseAlg,
 		),
 	)
 }
@@ -148,6 +155,7 @@ func createNewTlsClientAuth(
 	transportSubjectDn string,
 	requestObjectSignAlg string,
 	clientId string,
+	authorizationSignedResponseAlg string,
 ) Authoriser {
 	return NewTlsClientAuth(
 		config.TokenEndpoint,
@@ -166,6 +174,7 @@ func createNewTlsClientAuth(
 			transportCert,
 			transportSubjectDn,
 			clientId,
+			authorizationSignedResponseAlg,
 		),
 	)
 }

--- a/pkg/compliant/auth/authoriser_builder.go
+++ b/pkg/compliant/auth/authoriser_builder.go
@@ -22,11 +22,13 @@ type AuthoriserBuilder struct {
 	transportCertSubjectDn           string
 	preferredTokenEndpointAuthMethod string
 	clientId                         string
+	authorizationSignedResponseAlg   string
 }
 
 func NewAuthoriserBuilder() AuthoriserBuilder {
 	return AuthoriserBuilder{
-		jwtExpiration: time.Hour,
+		jwtExpiration:                  time.Hour,
+		authorizationSignedResponseAlg: "PS256",
 	}
 }
 
@@ -105,6 +107,11 @@ func (b AuthoriserBuilder) WithTokenEndpointSigningMethod(tokenEndpointSignMetho
 	return b
 }
 
+func (b AuthoriserBuilder) WithAuthorizationSignedResponseAlg(authorizationSignedResponseAlg string) AuthoriserBuilder {
+	b.authorizationSignedResponseAlg = authorizationSignedResponseAlg
+	return b
+}
+
 func (b AuthoriserBuilder) Build() (Authoriser, error) {
 	if b.ssa == "" {
 		return none{}, errors.New("missing ssa from authoriser")
@@ -133,5 +140,6 @@ func (b AuthoriserBuilder) Build() (Authoriser, error) {
 		b.transportCertSubjectDn,
 		b.preferredTokenEndpointAuthMethod,
 		b.clientId,
+		b.authorizationSignedResponseAlg,
 	), nil
 }

--- a/pkg/compliant/auth/authoriser_builder_test.go
+++ b/pkg/compliant/auth/authoriser_builder_test.go
@@ -61,5 +61,6 @@ func Test_AuthoriserBuilder_Success(t *testing.T) {
 		"",
 		"",
 		"",
+		"",
 	), authoriser)
 }

--- a/pkg/compliant/auth/authoriser_test.go
+++ b/pkg/compliant/auth/authoriser_test.go
@@ -39,6 +39,7 @@ func TestNewAuther_ReturnsClientSecretBasic(t *testing.T) {
 		"",
 		"",
 		"",
+		"",
 	)
 
 	assert.IsType(t, clientSecretBasic{}, auther)
@@ -61,6 +62,7 @@ func TestNewAuther_ReturnsPrivateKeyJwt(t *testing.T) {
 		&rsa.PrivateKey{},
 		time.Hour,
 		nil,
+		"",
 		"",
 		"",
 		"",
@@ -89,6 +91,7 @@ func TestNewAuther_ReturnsTlsClientAuth(t *testing.T) {
 		"",
 		"",
 		"",
+		"",
 	)
 
 	assert.IsType(t, tlsClientAuth{}, auther)
@@ -111,6 +114,7 @@ func TestNewAuther_ReturnsNoAuther(t *testing.T) {
 		&rsa.PrivateKey{},
 		time.Hour,
 		nil,
+		"",
 		"",
 		"",
 		"",

--- a/pkg/compliant/auth/client_secret_basic_test.go
+++ b/pkg/compliant/auth/client_secret_basic_test.go
@@ -32,6 +32,7 @@ func TestNewClientSecretBasicAuther_Claims(t *testing.T) {
 			nil,
 			"",
 			"",
+			"",
 		),
 	)
 
@@ -59,6 +60,7 @@ func TestClientSecretBasicAuther_Client_ReturnsAClient(t *testing.T) {
 			privateKey,
 			time.Hour,
 			nil,
+			"",
 			"",
 			"",
 		),

--- a/pkg/compliant/auth/client_secret_jwt_test.go
+++ b/pkg/compliant/auth/client_secret_jwt_test.go
@@ -30,6 +30,7 @@ func TestNewClientSecretJWT_Claims(t *testing.T) {
 			nil,
 			"",
 			"",
+			"",
 		),
 	)
 
@@ -57,6 +58,7 @@ func TestClientSecretJWT_Client_ReturnsAClient(t *testing.T) {
 			privateKey,
 			time.Hour,
 			nil,
+			"",
 			"",
 			"",
 		),

--- a/pkg/compliant/auth/signer.go
+++ b/pkg/compliant/auth/signer.go
@@ -15,20 +15,21 @@ type Signer interface {
 }
 
 type jwtSigner struct {
-	signingAlgorithm        jwt.SigningMethod
-	ssa                     string
-	issuer                  string
-	audience                string
-	kID                     string
-	tokenEndpointAuthMethod string
-	requestObjectSignAlg    string
-	redirectURIs            []string
-	responseTypes           []string
-	privateKey              *rsa.PrivateKey
-	jwtExpiration           time.Duration
-	transportCert           *x509.Certificate
-	transportSubjectDn      string
-	clientId                string
+	signingAlgorithm               jwt.SigningMethod
+	ssa                            string
+	issuer                         string
+	audience                       string
+	kID                            string
+	tokenEndpointAuthMethod        string
+	requestObjectSignAlg           string
+	redirectURIs                   []string
+	responseTypes                  []string
+	privateKey                     *rsa.PrivateKey
+	jwtExpiration                  time.Duration
+	transportCert                  *x509.Certificate
+	transportSubjectDn             string
+	clientId                       string
+	authorizationSignedResponseAlg string
 }
 
 func NewJwtSigner(
@@ -46,22 +47,24 @@ func NewJwtSigner(
 	transportCert *x509.Certificate,
 	transportSubjectDn string,
 	clientId string,
+	authorizationSignedResponseAlg string,
 ) Signer {
 	return jwtSigner{
-		signingAlgorithm:        signingAlgorithm,
-		ssa:                     ssa,
-		issuer:                  issuer,
-		audience:                audience,
-		kID:                     kID,
-		tokenEndpointAuthMethod: tokenEndpointAuthMethod,
-		requestObjectSignAlg:    requestObjectSignAlg,
-		redirectURIs:            redirectURIs,
-		responseTypes:           responseTypes,
-		privateKey:              privateKey,
-		jwtExpiration:           jwtExpiration,
-		transportCert:           transportCert,
-		transportSubjectDn:      transportSubjectDn,
-		clientId:                clientId,
+		signingAlgorithm:               signingAlgorithm,
+		ssa:                            ssa,
+		issuer:                         issuer,
+		audience:                       audience,
+		kID:                            kID,
+		tokenEndpointAuthMethod:        tokenEndpointAuthMethod,
+		requestObjectSignAlg:           requestObjectSignAlg,
+		redirectURIs:                   redirectURIs,
+		responseTypes:                  responseTypes,
+		privateKey:                     privateKey,
+		jwtExpiration:                  jwtExpiration,
+		transportCert:                  transportCert,
+		transportSubjectDn:             transportSubjectDn,
+		clientId:                       clientId,
+		authorizationSignedResponseAlg: authorizationSignedResponseAlg,
 	}
 }
 func (s jwtSigner) Claims() (string, error) {
@@ -114,6 +117,10 @@ func (s jwtSigner) Claims() (string, error) {
 
 	if s.responseTypes != nil {
 		claims["response_types"] = s.responseTypes
+	}
+
+	if s.authorizationSignedResponseAlg != "" {
+		claims["authorization_signed_response_alg"] = s.authorizationSignedResponseAlg
 	}
 
 	// Instead of potentially custom ASN/OID parsing to get exact, expected value of Subject DN

--- a/pkg/compliant/auth/signer_test.go
+++ b/pkg/compliant/auth/signer_test.go
@@ -31,6 +31,7 @@ func TestNewJwtSigner(t *testing.T) {
 		&x509.Certificate{},
 		"",
 		"",
+		"PS256",
 	)
 
 	signedClaims, err := signer.Claims()
@@ -61,6 +62,7 @@ func TestNewJwtSigner(t *testing.T) {
 	assert.Equal(t, "ssa", claims["software_statement"])
 	assert.Equal(t, "private_key_jwt", claims["token_endpoint_auth_method"])
 	assert.Equal(t, nil, claims["tls_client_auth_subject_dn"])
+	assert.Equal(t, "PS256", claims["authorization_signed_response_alg"])
 }
 
 func TestNewJwtSigner_TlsClientAuthAddSubjectToClaims(t *testing.T) {
@@ -82,6 +84,7 @@ func TestNewJwtSigner_TlsClientAuthAddSubjectToClaims(t *testing.T) {
 		&x509.Certificate{Subject: pkix.Name{Organization: []string{"OB"}}},
 		"",
 		"",
+		"",
 	)
 
 	token, claims := getJwtClaims(t, signer, privateKey)
@@ -100,6 +103,8 @@ func TestNewJwtSigner_TlsClientAuthAddSubjectToClaims(t *testing.T) {
 	assert.Equal(t, "ssa", claims["software_statement"])
 	assert.Equal(t, "tls_client_auth", claims["token_endpoint_auth_method"])
 	assert.Equal(t, "O=OB", claims["tls_client_auth_subject_dn"])
+
+	assert.NotContains(t, claims, "authorization_signed_response_alg")
 }
 
 func TestNewJwtSigner_TlsClientAuthAddConfigurableSubjectToClaims(t *testing.T) {
@@ -119,6 +124,7 @@ func TestNewJwtSigner_TlsClientAuthAddConfigurableSubjectToClaims(t *testing.T) 
 		time.Hour,
 		&x509.Certificate{Subject: pkix.Name{Organization: []string{"OB"}}},
 		"CN=Configured Subject DN",
+		"",
 		"",
 	)
 
@@ -162,6 +168,7 @@ func TestNewJwtSigner_TlsClientAuthDoesNotPanicOnMissingCert(t *testing.T) {
 		nil,
 		"",
 		"",
+		"",
 	)
 
 	_, err = signer.Claims()
@@ -188,6 +195,7 @@ func TestNewJwtSigner_OmitsEmptyResponseTypes(t *testing.T) {
 		privateKey,
 		time.Hour,
 		&x509.Certificate{Subject: pkix.Name{Organization: []string{"OB"}}},
+		"",
 		"",
 		"",
 	)

--- a/pkg/compliant/dcr32_config.go
+++ b/pkg/compliant/dcr32_config.go
@@ -46,6 +46,7 @@ func NewDCR32Config(
 	specVersion string,
 	preferredTokenEndpointAuthMethod string,
 	createSoftwareClientOnly bool,
+	authorizationSignedResponseAlg string,
 ) (DCR32Config, error) {
 	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(signingKeyPEM))
 	if err != nil {
@@ -85,7 +86,8 @@ func NewDCR32Config(
 		WithTokenEndpointAuthMethod(tokenSignMethod).
 		WithTransportCert(transportCert).
 		WithTransportCertSubjectDn(transportCertSubjectDn).
-		WithPreferredTokenEndpointAuthMethod(preferredTokenEndpointAuthMethod)
+		WithPreferredTokenEndpointAuthMethod(preferredTokenEndpointAuthMethod).
+		WithAuthorizationSignedResponseAlg(authorizationSignedResponseAlg)
 
 	secureClient, err := http.NewBuilder().
 		WithRootCAs(transportRootCAs).

--- a/pkg/compliant/dcr32_config_test.go
+++ b/pkg/compliant/dcr32_config_test.go
@@ -37,6 +37,7 @@ func TestNewDCR32Config(t *testing.T) {
 		"3.2",
 		"",
 		false,
+		"PS256",
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
authorization_signed_response_alg can now be supplied via config, this controls the signing algorithm used to sign JARM responses.

Default value of `PS256` is used, as this is required by FAPI.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1390