### PR TITLE
1390: Removing setting the default value for authorization_signed_response_alg in code

### DIFF
--- a/pkg/compliant/auth/authoriser_builder.go
+++ b/pkg/compliant/auth/authoriser_builder.go
@@ -27,8 +27,7 @@ type AuthoriserBuilder struct {
 
 func NewAuthoriserBuilder() AuthoriserBuilder {
 	return AuthoriserBuilder{
-		jwtExpiration:                  time.Hour,
-		authorizationSignedResponseAlg: "PS256",
+		jwtExpiration: time.Hour,
 	}
 }
 

--- a/templates/sbat-conformance-config.jq
+++ b/templates/sbat-conformance-config.jq
@@ -17,5 +17,6 @@
   "delete_implemented": true,
   "environment": "sandbox",
   "brand": "Brand/product",
-  "preferred_token_endpoint_auth_method": $token_endpoint_auth_method
+  "preferred_token_endpoint_auth_method": $token_endpoint_auth_method,
+  "authorization_signed_response_alg": "PS256"
 }

--- a/templates/sbat-create-dcr-config.jq
+++ b/templates/sbat-create-dcr-config.jq
@@ -17,5 +17,6 @@
   "delete_implemented": false,
   "environment": "sandbox",
   "brand": "Brand/product",
-  "preferred_token_endpoint_auth_method": $token_endpoint_auth_method
+  "preferred_token_endpoint_auth_method": $token_endpoint_auth_method,
+  "authorization_signed_response_alg": "PS256"
 }


### PR DESCRIPTION
Removing the default gives us the flexibility to test doing a DCR with this configuration omitted.

Updating the config templates used by SAPI-G to set the value to PS256.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1390